### PR TITLE
fix: remove a work around to reset the internal runtime buffer

### DIFF
--- a/lib/template-api.js
+++ b/lib/template-api.js
@@ -131,9 +131,6 @@ module.exports = function (
       attachRuntimeEnvironment(runtime, runtimeEnvironment);
       // Execute runtime to populate templates
       await run(runtime).catch(() => {});
-      // Runtime calls are not encapsulated and memory is not released
-      // Without resetting the buffer all previous rendering will still be present
-      runtime.dom._buf = "";
       // @ts-expect-error
       const templates = runtime.template();
       if (Object.keys(templates).length === 0) {
@@ -151,7 +148,6 @@ module.exports = function (
       }
       // Execute template
       return runtime.run(function* () {
-        // @ts-expect-error - No idea why dom would not have a start method
         const $n = runtime.dom.start();
         yield runtime.call(templates[templateName], [$n, templateParameters]);
         return runtime.dom.end();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "repository": "github:jantimon/htl-template-loader",
   "license": "MIT",
   "devDependencies": {
-    "@adobe/htlengine": "^4.6.0",
+    "@adobe/htlengine": "^4.6.2",
     "fs-extra": "^9.0.1",
     "husky": "^4.2.5",
     "memfs": "3.2.0",
@@ -37,7 +37,7 @@
     "webpack-cli": "^3.3.11"
   },
   "peerDependencies": {
-    "@adobe/htlengine": "^4.5.0"
+    "@adobe/htlengine": "^4.6.2"
   },
   "dependencies": {
     "loader-utils": "^2.0.0"


### PR DESCRIPTION
BREAKING CHANGE: Drop support for @adobe/htlengine older than ^4.6.2

Thanks to https://github.com/adobe/htlengine/issues/211 we can remove this hack! :)